### PR TITLE
Update `deploy.md`with voteskip command

### DIFF
--- a/doc/deploy.md
+++ b/doc/deploy.md
@@ -40,6 +40,7 @@ _shuffle : Shuffles the entire queue of songs
 _s, _skip : Skips the currently playing music
 _r, _remove : removes song from queue at index given.
 _l, _leave : Commands the bot to leave the voice channel
+ _voteskip : Initiates voting from the voice members to skip a song.
 _h, _help : shows all the commands of the bot.
 _prefix : Change prefix of the bot. (Restart Required)
 ```


### PR DESCRIPTION
The voteskip command, despite already being available and included in the output of the `--help` command, is not included in the `deploy.md` file. This commit fixes that.

Issue: None