### PR TITLE
Also show the `help` command when typing `--help`

### DIFF
--- a/help.py
+++ b/help.py
@@ -9,7 +9,7 @@ class Help(commands.Cog):
         self.bot = bot
         self.bot_cogs = self.bot.cogs
 
-    @commands.command(hidden=True, name="help", aliases=["h"])
+    @commands.command(name="help", aliases=["h"])
     async def _help(self, ctx, cog_query: str = "Music"):
         """Returns all not hidden commands from a cog.
         Default query is set to 'Music' but other cogs are supported too"""


### PR DESCRIPTION
As documented in [1], removing the `hidden=True` should fix this.

[1] https://github.com/Rapptz/discord.py/blob/45d498c1b76deaf3b394d17ccf56112fa691d160/discord/ext/commands/core.py#L244-L246

Issue: closes #59