### PR TITLE
Add majority vote (>=50%) to playnext command

### DIFF
--- a/music.py
+++ b/music.py
@@ -205,7 +205,7 @@ class Music(commands.Cog):
                     "If more than 50% of the people in your channel agree, the request will be up next!"
                 )
                 await vote_message.add_reaction("\U0001F44D")
-                await asyncio.sleep(3)
+                await asyncio.sleep(30)
                 voters = len(voice_channel.members)
                 voters = voters - 1 if self.vc else voters
                 result_vote_msg = await ctx.fetch_message(vote_message.id)


### PR DESCRIPTION
`_pn` (Play next) will ask people to vote for the next 30s to confirm the request to move the song to the top of the queue, else it will append to the end of the queue .

Closes #27 
